### PR TITLE
Fix TYAttributedLabel intrinsicContentSize, suggest width may be less than max width.

### DIFF
--- a/TYAttributedLabelDemo/TYAttributedLabel/TYAttributedLabel.m
+++ b/TYAttributedLabelDemo/TYAttributedLabel/TYAttributedLabel.m
@@ -546,7 +546,7 @@ NSString *const kTYTextRunAttributedName = @"TYTextRunAttributedName";
 
 - (CGSize)intrinsicContentSize
 {
-    return CGSizeMake(self.preferredMaxLayoutWidth, [self getHeightWithWidth:self.preferredMaxLayoutWidth]);
+    return [_textContainer getSuggestedSizeWithFramesetter:nil width:self.preferredMaxLayoutWidth];
 }
 
 #pragma mark - set right frame

--- a/TYAttributedLabelDemo/TYAttributedLabel/TYTextContainer.h
+++ b/TYAttributedLabelDemo/TYAttributedLabel/TYTextContainer.h
@@ -53,6 +53,8 @@
  */
 - (int)getHeightWithFramesetter:(CTFramesetterRef)framesetter width:(CGFloat)width;
 
+- (CGSize)getSuggestedSizeWithFramesetter:(CTFramesetterRef)framesetter width:(CGFloat)width;
+
 @end
 
 @interface TYTextContainer (Add)

--- a/TYAttributedLabelDemo/TYAttributedLabel/TYTextContainer.m
+++ b/TYAttributedLabelDemo/TYAttributedLabel/TYTextContainer.m
@@ -401,28 +401,34 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
 
 - (int)getHeightWithFramesetter:(CTFramesetterRef)framesetter width:(CGFloat)width
 {
+    return [self getSuggestedSizeWithFramesetter:framesetter width:width].height;
+}
+
+- (CGSize)getSuggestedSizeWithFramesetter:(CTFramesetterRef)framesetter width:(CGFloat)width
+{
     if (_attString == nil || width <= 0) {
-        return 0;
+        return CGSizeZero;
     }
     
     if (_textHeight > 0) {
-        return _textHeight;
+        return CGSizeMake(_textWidth, _textHeight);
     }
     
     // 是否需要更新frame
     if (framesetter == nil) {
-        
         framesetter = CTFramesetterCreateWithAttributedString((CFAttributedStringRef)[self createAttributedString]);
     }else {
         CFRetain(framesetter);
     }
     
     // 获得建议的size
-    CGSize suggestedSize = CTFramesetterSuggestFrameSizeForAttributedStringWithConstraints(framesetter, _attString, CGSizeMake(width,MAXFLOAT), _numberOfLines);
-    
+    CGSize suggestedSize = CTFramesetterSuggestFrameSizeForAttributedStringWithConstraints(framesetter,
+                                                                                           _attString,
+                                                                                           CGSizeMake(width,MAXFLOAT),
+                                                                                           _numberOfLines);
     CFRelease(framesetter);
-    
-    return suggestedSize.height+1;
+    suggestedSize.height += 1;
+    return suggestedSize;
 }
 
 -  (CTFrameRef)createFrameRefWithFramesetter:(CTFramesetterRef)framesetter textHeight:(CGFloat)textHeight


### PR DESCRIPTION
目前 intrinsicContentSize 返回的宽度总是最大限制宽度，
但是少于一行时，可能返回自动调整后的宽度会好些。