### PR TITLE
解决lineBreakMode设置为CTLineBreakByTruncatingTail之后，不换行问题

### DIFF
--- a/TYAttributedLabelDemo/TYAttributedLabel/TYTextContainer.m
+++ b/TYAttributedLabelDemo/TYAttributedLabel/TYTextContainer.m
@@ -294,7 +294,7 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
 #pragma mark -  add text storage atrributed
 - (void)addTextStoragesWithAtrributedString:(NSMutableAttributedString *)attString
 {
-    
+    // lineBreakMode设置为CTLineBreakByTruncatingTail之后，不换行
     if (attString) {
         
         // 字体大小

--- a/TYAttributedLabelDemo/TYAttributedLabel/TYTextContainer.m
+++ b/TYAttributedLabelDemo/TYAttributedLabel/TYTextContainer.m
@@ -294,6 +294,27 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
 #pragma mark -  add text storage atrributed
 - (void)addTextStoragesWithAtrributedString:(NSMutableAttributedString *)attString
 {
+    
+    if (attString) {
+        
+        // 字体大小
+        [self setAttributeWithAttributeString:attString name:NSFontAttributeName value:_font];
+        // 字体颜色
+        [self setAttributeWithAttributeString:attString name:NSForegroundColorAttributeName value:_textColor];
+        // 字体段落
+        NSMutableParagraphStyle *para = [[NSMutableParagraphStyle alloc] init];
+        para.lineSpacing = _linesSpacing;
+        para.paragraphSpacing = _paragraphSpacing;
+        
+        [self setAttributeWithAttributeString:attString name:NSParagraphStyleAttributeName value:para];
+        
+        // 空心字边框颜色
+        [self setAttributeWithAttributeString:attString name:NSStrokeColorAttributeName value:_strokeColor];
+        // 空心字边框宽
+        [self setAttributeWithAttributeString:attString name:NSStrokeWidthAttributeName value:@(_strokeWidth)];
+        
+    }
+    
     if (attString && _textStorageArray.count > 0) {
         
         // 排序range
@@ -332,6 +353,16 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
         }
         _textStorages = [_textStorageArray copy];
         [_textStorageArray removeAllObjects];
+    }
+}
+
+- (void)setAttributeWithAttributeString:(NSMutableAttributedString *)mutableAttString
+                                   name:(NSString *)attributeName
+                                  value:(id)value
+{
+    if (value) {
+        
+        [mutableAttString addAttribute:attributeName value:value range:NSMakeRange(0, mutableAttString.length)];
     }
 }
 

--- a/TYAttributedLabelDemo/TextContainerViewController.m
+++ b/TYAttributedLabelDemo/TextContainerViewController.m
@@ -59,6 +59,14 @@
     TYTextContainer *textContainer = [[TYTextContainer alloc]init];
     textContainer.text = text;
     
+    // 整体设置属性
+    textContainer.lineBreakMode = NSLineBreakByTruncatingTail;
+    textContainer.numberOfLines = 5;
+    
+    //textContainer.font = [UIFont italicSystemFontOfSize:25];
+    textContainer.linesSpacing = 15;
+    textContainer.paragraphSpacing = 5;
+    
     // 文字样式
     TYTextStorage *textStorage = [[TYTextStorage alloc]init];
     textStorage.range = [text rangeOfString:@"蒹葭"];


### PR DESCRIPTION
- 当我们同时给TYTextContainer设置font/linesSpacing等属性,  和textStorage时, 发现文字总是只有一行, 想来应该是你没有使用直接设置的font/linesSpacing等属性. 
- 经我们修改后, 发现现实正常,具体请参考compare内容.