### PR TITLE
feat: 增加非自定义响应区域长按代理

### DIFF
--- a/TYAttributedLabelDemo/TYAttributedLabel/TYAttributedLabel.h
+++ b/TYAttributedLabelDemo/TYAttributedLabel/TYAttributedLabel.h
@@ -24,6 +24,9 @@ typedef NS_ENUM(NSUInteger, TYVerticalAlignment) {
 
 // 长按代理 有多个状态 begin, changes, end 都会调用,所以需要判断状态
 - (void)attributedLabel:(TYAttributedLabel *)attributedLabel textStorageLongPressed:(id<TYTextStorageProtocol>)textStorage onState:(UIGestureRecognizerState)state atPoint:(CGPoint)point;
+    
+// 长按非Container区域代理 有多个状态 begin, changes, end 都会调用,所以需要判断状态
+- (void)attributedLabel:(TYAttributedLabel *)attributedLabel lableLongPressOnState:(UIGestureRecognizerState)state atPoint:(CGPoint)point;
 @end
 
 /**

--- a/TYAttributedLabelDemo/TYAttributedLabel/TYAttributedLabel.m
+++ b/TYAttributedLabelDemo/TYAttributedLabel/TYAttributedLabel.m
@@ -367,11 +367,16 @@ NSString *const kTYTextRunAttributedName = @"TYTextRunAttributedName";
     CGPoint point = [sender locationInView:self];
     point = [self covertTapPiont:point];
     __typeof (self) __weak weakSelf = self;
-    [_textContainer enumerateRunRectContainPoint:point viewHeight:CGRectGetHeight(self.frame) successBlock:^(id<TYTextStorageProtocol> textStorage){
+    bool didPressContainer = [_textContainer enumerateRunRectContainPoint:point viewHeight:CGRectGetHeight(self.frame) successBlock:^(id<TYTextStorageProtocol> textStorage){
         if (_delegateFlags.textStorageLongPressedOnStateAtPoint) {
                 [weakSelf.delegate attributedLabel:weakSelf textStorageLongPressed:textStorage onState:sender.state atPoint:point];
         }
     }];
+    // 非响应容器区域响应长按事件
+    if (didPressContainer == NO && [weakSelf respondsToSelector:@selector(attributedLabel:lableLongPressOnState:atPoint:)]) {
+        [weakSelf.delegate attributedLabel:weakSelf lableLongPressOnState:sender.state atPoint:point];
+    }
+
 }
 
 #pragma mark - touches action


### PR DESCRIPTION
增加了label非容器区域的长按代理，这样方便更统一的操作。
比如：评论列表，长按举报的逻辑代码就能通过TY的代理统一响应非文字区域的长按手势。